### PR TITLE
CI: Add flatpak build

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,59 @@
+name: Flatpak
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build-flatpak:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
+      options: --privileged
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            name: amd64
+            os: ubuntu-24.04
+
+          - arch: aarch64
+            name: aarch64
+            os: ubuntu-24.04-arm
+
+      # Don't fail the whole workflow if one architecture fails
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: io.github.userwithaname.Mellow.${{ matrix.arch }}.flatpak
+          manifest-path: io.github.userwithaname.Mellow.yaml
+          arch: ${{ matrix.arch }}
+          upload-artifact: false
+
+      - name: Upload flatpak to action
+        uses: actions/upload-artifact@v7
+        with:
+          name: io.github.userwithaname.Mellow.${{ matrix.arch }}.flatpak
+          path: io.github.userwithaname.Mellow.${{ matrix.arch }}.flatpak
+
+      - name: Upload flatpak to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: io.github.userwithaname.Mellow.${{ matrix.arch }}.flatpak
+          tag: ${{ github.ref }}
+          file_glob: true
+          overwrite: true


### PR DESCRIPTION
Adds a github action to build the flatpaks for pull requests, tags and manual calls.

I was originally gonna have it run on all commits but considering you have 1k+ commits i dont think it would make sense for all those to have builds. Instead i added the option for you to manually call a build and it will upload the flatpak file to action run itself as a attachment. 

For releases you just have to create a github release with a tag and it will generate the flatpak for both x86_64 and aarch64 and attach them to the release so you dont have to build it externally.

Added pull requests that way it makes it easy to test new features/fixes that people submit PR with.